### PR TITLE
Reformat according to markdown lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,13 @@ By default, the LaTeX toolchain won’t attempt to look for styles, classes, and
 If you build your paper with [`latexmk`][latexmk] (we can only recommend that), this can be easily solved.
 Simply copy the [`.latexmkrc`][.latexmkrc] file to the top level of your repository,
 and LaTeX will automatically find any styles, classes, and bibliographies in the `include` folder if you run with `latexmk`:
+
 ```sh
-$ latexmk -pdf paper.tex
+latexmk -pdf paper.tex
 ```
 
 If you do not use `latexmk`, you need to set the following environment variables in your `.bashrc` or LaTeX IDE instead:
+
 ```sh
 export BIBINPUTS="./include//:"
 export BSTINPUTS="./include//:"
@@ -75,15 +77,18 @@ export TEXINPUTS="./include//:"
 ### Adding Submodules
 
 Add the repository as a submodule to your paper repository as follows:
+
 ```sh
-$ git submodule add ../<name> include/<name>
+git submodule add ../<name> include/<name>
 ```
+
 (Replace `../<name>` with `https://github.com/krr-up/<name>` if your repository is hosted outside of the [`krr-up` organization][krr-up].)
 
 Next, commit and push the changes to make the submodule available to your coworkers.
 After your coworkers have pulled the change, they will need to execute the following command:
+
 ```sh
-$ git submodule update --init --recursive
+git submodule update --init --recursive
 ```
 
 The submodule will now stay at the latest state of the `master` branch at the time of adding it unless manually updated later on.
@@ -93,20 +98,23 @@ The submodule will now stay at the latest state of the `master` branch at the ti
 You can bring the latest changes to your paper repository as follows:
 
 ```sh
-$ cd include/<name>
-$ git fetch
-$ git reset --hard origin/master
-$ cd ../..
-$ git add include/<name>
-$ git commit -m "Update <name>"
-$ git push
+cd include/<name>
+git fetch
+git reset --hard origin/master
+cd ../..
+git add include/<name>
+git commit -m "Update <name>"
+git push
 ```
 
 Finally, keep in mind that you need to run
+
 ```sh
-$ git submodule update --init --recursive
+git submodule update --init --recursive
 ```
+
 every time one of the following happens:
+
 - You clone your paper repository from scratch.
 - Someone else updates the submodule to to a newer version.
 - Files in `include/<name>` are missing or LaTeX complains about them.
@@ -115,16 +123,17 @@ every time one of the following happens:
 
 ### Available Submodules
 
-- https://github.com/krr-up/bibliography
-- https://github.com/krr-up/latex-style-comments
-- https://github.com/krr-up/asp-macros
-- https://github.com/krr-up/logos
+- <https://github.com/krr-up/bibliography>
+- <https://github.com/krr-up/latex-style-comments>
+- <https://github.com/krr-up/asp-macros>
+- <https://github.com/krr-up/logos>
 
 For licensing reasons, we set the visibility of the following repositories to private:
-- https://github.com/krr-up/latex-class-llncs
-- https://github.com/krr-up/latex-class-eptcs
-- https://github.com/krr-up/latex-style-aaai
-- https://github.com/krr-up/latex-class-tlp
+
+- <https://github.com/krr-up/latex-class-llncs>
+- <https://github.com/krr-up/latex-class-eptcs>
+- <https://github.com/krr-up/latex-style-aaai>
+- <https://github.com/krr-up/latex-class-tlp>
 
 [beamer]: https://github.com/josephwright/beamer
 [feature branch workflow]: https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow


### PR DESCRIPTION
I reformatted the README using [markdownlint](https://github.com/DavidAnson/markdownlint).
Most notably this removes the dollar sign in the shell code snippets [MD014](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md014). This allows the reader to directly copy the snipped and paste it into the console.